### PR TITLE
Multi-archticture & Travis CI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+image/daemon

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,69 @@
+os: linux
+dist: bionic
+language: go
+go:
+  - 1.14.x
+services:
+  - docker
+before_script:
+  - sudo chmod 755 /etc/docker
+
+addons:
+  apt:
+    packages:
+      - "libgpgme-dev"
+      - "libdevmapper-dev"
+
+stages:
+  - deploy
+  - deploy-multi-arch
+
+jobs:
+  include:
+
+  # Build and push the image for amd64
+  - stage: deploy
+    name: Build image for kata-operator-daemon (amd64)
+    arch: amd64
+    deploy:
+      provider: script
+      script: bash hack/deploy.sh
+      skip_cleanup: true
+      on:
+        all_branches: true
+        condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$
+
+  # Build and push the image for ppc64le
+  - stage: deploy
+    name: Build image for kata-operator-daemon (ppc64le)
+    arch: ppc64le
+    deploy:
+      provider: script
+      script: bash hack/deploy.sh
+      skip_cleanup: true
+      on:
+        all_branches: true
+        condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$
+
+  # Build and push the image for s390x
+  - stage: deploy
+    name: Build image for kata-operator-daemon (s390x)
+    arch: s390x
+    deploy:
+      provider: script
+      script: bash hack/deploy.sh
+      skip_cleanup: true
+      on:
+        all_branches: true
+        condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$
+
+  # Deploy the multiarch manifest
+  - stage: deploy-multi-arch
+    name: Deploy multi-arch manifest
+    deploy:
+      provider: script
+      script: bash hack/deploy-multi-arch.sh
+      skip_cleanup: true
+      on:
+        all_branches: true
+        condition: $TRAVIS_BRANCH =~ ^(release-.*|master)$

--- a/hack/deploy-multi-arch.sh
+++ b/hack/deploy-multi-arch.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -xe
+
+IMAGE_NAME="quay.io/isolatedcontainers/kata-operator-daemon"
+
+if "${TRAVIS_BRANCH}" == "master"; then
+	TAG="latest"
+else
+	TAG="$(echo ${TRAVIS_BRANCH} | awk '{print $2}' FS='-')"
+fi
+
+docker login \
+	--username="${QUAY_USERNAME}" \
+	--password="${QUAY_PASSWORD}" \
+	quay.io
+
+env DOCKER_CLI_EXPERIMENTAL="enabled" docker manifest create \
+	"$IMAGE_NAME:$TAG" \
+	"$IMAGE_NAME:$TAG-amd64" \
+	"$IMAGE_NAME:$TAG-ppc64le" \
+	"$IMAGE_NAME:$TAG-s390x"
+
+env DOCKER_CLI_EXPERIMENTAL="enabled" docker manifest push \
+	--purge \
+	"$IMAGE_NAME:$TAG"

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -xe
+
+go build -o image/daemon cmd/daemon/main.go
+
+IMAGE_NAME="quay.io/isolatedcontainers/kata-operator-daemon"
+
+if "${TRAVIS_BRANCH}" == "master"; then
+	TAG="latest-${TRAVIS_CPU_ARCH}"
+else
+	TAG="$(echo ${TRAVIS_BRANCH} | awk '{print $2}' FS='-')-${TRAVIS_CPU_ARCH}"
+fi
+
+docker login \
+	--username="${QUAY_USERNAME}" \
+	--password="${QUAY_PASSWORD}" \
+	quay.io
+
+docker build \
+	--tag "${IMAGE_NAME}:${TAG}" \
+	image
+
+docker push "${IMAGE_NAME}:${TAG}"


### PR DESCRIPTION
@jensfr, @harche,

This PR consists in a few different patches, bringing up multi architecture support and then taking advantage of Travis CI in order to generate and upload the images for the different architectures automatically.

**Dockerfile**

* Add ARCH as a build argument
  + This will allow us to easily build for PPC64LE (and other architectures of our interest)

**Travis CI**

* Build & update the image using Travis CI
  + This commit requires a some configurations done beforehand such as:
      - Travis CI must be enabled by the owner of the repo;
      - QUAY_USERNAME and QUAY_PASSWORD must be set, as secrets, on Travis CI side;
   + And also an agreement about the branches naming that will be adopted and will be used as basis for the image name, such as:
      - ocp-x.y for the images that should be used together with OCP x.y, generating images named "x.y-$arch";
      - master will generate images names "latest-$arch";
      - any other branch name will not trigger Travis CI;

Notes

* A similar PR has to be provided to the other repos, you can easily take this one as basis for the work that has to be done.
* The code, everywhere, must be updated so it becomes robust enough to deal with the proposed naming for the images.