### PR TITLE
adapt to name change of crio dropin config file

### DIFF
--- a/pkg/daemon/kata_openshift.go
+++ b/pkg/daemon/kata_openshift.go
@@ -95,7 +95,7 @@ func (k *KataOpenShift) Install(kataConfigResourceName string) error {
 	if isKataInstalled {
 		// kata exist - mark completion if crio drop in file exists
 		if k.CRIODropinPath == "" {
-			k.CRIODropinPath = "/host/etc/crio/crio.conf.d/kata-50.conf"
+			k.CRIODropinPath = "/host/etc/crio/crio.conf.d/50-kata.conf"
 		}
 		if _, err := os.Stat(k.CRIODropinPath); err == nil {
 			err = updateKataConfigStatus(k.KataClientSet, kataConfigResourceName, func(ks *kataTypes.KataConfigStatus) {


### PR DESCRIPTION
Change the file name according to dropin file name convention.

This needs to be merged along with PR #39 in kata-operator repo. 

Signed-off-by: Jens Freimann <jfreimann@redhat.com>