### PR TITLE
clean up temporary directories after installation

### DIFF
--- a/pkg/daemon/kata_openshift.go
+++ b/pkg/daemon/kata_openshift.go
@@ -424,6 +424,11 @@ func installRPMs(k *v1alpha1.KataConfig) error {
 		return err
 	}
 
+	err = cleanupHost()
+	if err != nil {
+		log.Println("cleanupHost failed")
+	}
+
 	return nil
 
 }


### PR DESCRIPTION
We don't need to wait to delete these directories until uninstall.
When installation is done get rid of it.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>