### PR TITLE
return clusterversion as major.minor.patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/containers/image/v5 v5.0.0
+	github.com/coreos/go-semver v0.3.0
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/opencontainers/image-tools v1.0.0-rc1.0.20190306063041-93db3b16e673
 	github.com/openshift/kata-operator v0.0.0-00010101000000-000000000000

--- a/pkg/daemon/kata_openshift.go
+++ b/pkg/daemon/kata_openshift.go
@@ -6,11 +6,13 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/coreos/go-semver/semver"
 	"github.com/opencontainers/image-tools/image"
 	confv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	kataTypes "github.com/openshift/kata-operator/pkg/apis/kataconfiguration/v1alpha1"
@@ -443,5 +445,10 @@ func getClusterVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return clusterversion.Status.Desired.Version[:5], nil
+	mysemver, err := semver.NewVersion(clusterversion.Status.Desired.Version)
+	if err != nil {
+		return "", err
+	}
+	versl := mysemver.Slice()
+	return strings.Trim(strings.Replace(fmt.Sprint(versl), " ", ".", -1), "[]"), nil
 }


### PR DESCRIPTION
Fix code that returns the cluster version as a string. It was a fixed-length 5 char string, which doesn't work
if the major.minor.patch formatted version is > 5 characters. Use a go module that parses a semver version string
and return the correct string.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>